### PR TITLE
Add @RequestBody to parameter user in POST

### DIFF
--- a/dummy-back/src/main/java/com/dummyback/controllers/UsersController.java
+++ b/dummy-back/src/main/java/com/dummyback/controllers/UsersController.java
@@ -31,7 +31,7 @@ public class UsersController {
 	}
 	
 	@PostMapping("users")
-	public User saveUser(final User user) {
+	public User saveUser(@RequestBody final User user) {
 		
 		LOGGER.debug("Request for a new user");
 		final User u = this.usersRepository.save(user);


### PR DESCRIPTION
Add @RequestBody in parameter user because without the annotation the attributes of the object are received to null.